### PR TITLE
Updates the findripe cmake file to search for the .so file

### DIFF
--- a/cmake/FindRipe.cmake
+++ b/cmake/FindRipe.cmake
@@ -27,7 +27,7 @@ if (RIPE_USE_STATIC_LIBS)
 else()
     message ("-- Ripe: Dynamic linking")
     find_library(RIPE_LIBRARY
-        NAMES libripe.dylib
+        NAMES libripe.dylib libripe.so
         HINTS "${CMAKE_PREFIX_PATH}/lib"
     )
 endif()


### PR DESCRIPTION
The FindRipe cmake file in the repo was only looking for the libripe.dylib file.
I had to add the libripe.so filename to be able to compile in Ubuntu.

I am not sure if a better solution exist, and Cmake can automatically look for the specific version of the file under each OS, but this one seems to work nevertheless.